### PR TITLE
Cleaned up the requirements list

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,8 @@ Install these with pip install *package name*
 - pydub
 - git+https://github.com/kokarare1212/librespot-python
 
-ffmpeg can be installed via apt for Debian-based distros or by downloading the
-binaries from [ffmpeg.org](https://ffmpeg.org) and placing them in your %PATH% in Windows.
 ```
+ffmpeg can be installed via apt for Debian-based distros or by downloading the binaries from [ffmpeg.org](https://ffmpeg.org) and placing them in your %PATH% in Windows.
 
 - Use "-p" or "--playlist" to download a saved playlist from our account
 - Supply the URL or ID of a Track/Album/Playlist as an argument to download it

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Install these with pip install *package name*
 - pydub
 - git+https://github.com/kokarare1212/librespot-python
 
-ffmpeg can be installed via apt for Debian-based distros or by downloading the binaries and placing them in your %PATH% in Windows.
+ffmpeg can be installed via apt for Debian-based distros or by downloading the
+binaries from [ffmpeg.org](https://ffmpeg.org) and placing them in your %PATH% in Windows.
 ```
 
 - Use "-p" or "--playlist" to download a saved playlist from our account

--- a/README.md
+++ b/README.md
@@ -2,14 +2,24 @@
 Spotify song downloader without injecting into the windows client
 ![image](https://user-images.githubusercontent.com/12180913/137086248-371a3d81-75b3-4d75-a90c-966549c45745.png)
 ```
-sudo apt install ffmpeg (For windows download the binarys and place it in %PATH%)
-pip install requests
-pip install music_tag
-pip install pydub
-pip install websocket-client
-pip install git+https://github.com/kokarare1212/librespot-python
-```
+### Requirements:
 
+Binaries
+
+\- Python 3.8 or greater
+\- ffmpeg\*
+
+Python packages:
+
+Install these with pip install *package name*
+
+\- websocket-client
+\- requests
+\- music_tag
+\- pydub
+\- git+https://github.com/kokarare1212/librespot-python
+```
+ffmpeg can be installed via apt for Debian-based distros or by downloading the binaries and placing them in your %PATH% in Windows.
 
 - Use "-p" or "--playlist" to download a saved playlist from our account
 - Supply the URL or ID of a Track/Album/Playlist as an argument to download it

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Install these with pip install *package name*
 - git+https://github.com/kokarare1212/librespot-python
 
 ```
-ffmpeg can be installed via apt for Debian-based distros or by downloading the binaries from [ffmpeg.org](https://ffmpeg.org) and placing them in your %PATH% in Windows.
+\*ffmpeg can be installed via apt for Debian-based distros or by downloading the binaries from [ffmpeg.org](https://ffmpeg.org) and placing them in your %PATH% in Windows.
 
 - Use "-p" or "--playlist" to download a saved playlist from our account
 - Supply the URL or ID of a Track/Album/Playlist as an argument to download it

--- a/README.md
+++ b/README.md
@@ -1,25 +1,27 @@
 # zspotify
 Spotify song downloader without injecting into the windows client
 ![image](https://user-images.githubusercontent.com/12180913/137086248-371a3d81-75b3-4d75-a90c-966549c45745.png)
+
 ```
-### Requirements:
+Requirements:
 
 Binaries
 
-\- Python 3.8 or greater
-\- ffmpeg\*
+- Python 3.8 or greater
+- ffmpeg*
 
 Python packages:
 
 Install these with pip install *package name*
 
-\- websocket-client
-\- requests
-\- music_tag
-\- pydub
-\- git+https://github.com/kokarare1212/librespot-python
-```
+- websocket-client
+- requests
+- music_tag
+- pydub
+- git+https://github.com/kokarare1212/librespot-python
+
 ffmpeg can be installed via apt for Debian-based distros or by downloading the binaries and placing them in your %PATH% in Windows.
+```
 
 - Use "-p" or "--playlist" to download a saved playlist from our account
 - Supply the URL or ID of a Track/Album/Playlist as an argument to download it

--- a/README.md
+++ b/README.md
@@ -12,13 +12,11 @@ Binaries
 
 Python packages:
 
-Install these with pip install *package name*
-
-- websocket-client
-- requests
-- music_tag
-- pydub
-- git+https://github.com/kokarare1212/librespot-python
+- pip install websocket-client
+- pip install requests
+- pip install music_tag
+- pip install pydub
+- pip install git+https://github.com/kokarare1212/librespot-python
 
 ```
 \*ffmpeg can be installed via apt for Debian-based distros or by downloading the binaries from [ffmpeg.org](https://ffmpeg.org) and placing them in your %PATH% in Windows.


### PR DESCRIPTION
Didn't see you added websocket-client (figured that out the hard way) but also added that this requires Python 3.8 or newer (https://bugs.python.org/issue35143)