### PR TITLE
Don't skip download if local file is empty.

### DIFF
--- a/zspotify.py
+++ b/zspotify.py
@@ -573,7 +573,7 @@ def download_track(track_id_str: str, extra_paths=""):
                 print("###   SKIPPING:", song_name,
                       "(SONG IS UNAVAILABLE)   ###")
             else:
-                if os.path.isfile(filename) and SKIP_EXISTING_FILES:
+                if os.path.isfile(filename) and os.path.getsize(filename) and SKIP_EXISTING_FILES:
                     print("###   SKIPPING:", song_name,
                           "(SONG ALREADY EXISTS)   ###")
                 else:


### PR DESCRIPTION
If a download gets aborted for some reasons, zspotify left behind a 0 length
file which caused the song to be skipped on the next run. This commit checks
for a non-zero filesize before deciding whether to skip the download of an
"existing" file or not.