### PR TITLE
added basic Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.9-alpine as base
+
+RUN apk --update add git ffmpeg
+
+FROM base as builder
+RUN mkdir /install
+WORKDIR /install
+COPY requirements.txt /requirements.txt
+RUN apk add gcc libc-dev zlib zlib-dev jpeg-dev \
+    && pip install --prefix="/install" -r /requirements.txt
+
+
+FROM base
+
+COPY --from=builder /install /usr/local
+COPY src /app
+COPY zs_config.json /
+WORKDIR /app
+ENTRYPOINT ["/usr/local/bin/python", "app.py"]


### PR DESCRIPTION
this config builds a small-ish (141Mb) docker image and allows running the tool via command line:
```
docker build . -t zspotify
docker run --rm -it zspotify
```