### PR TITLE
Added function to check song duration for #162

### DIFF
--- a/zspotify/const.py
+++ b/zspotify/const.py
@@ -2,6 +2,8 @@ SAVED_TRACKS_URL = 'https://api.spotify.com/v1/me/tracks'
 
 TRACKS_URL = 'https://api.spotify.com/v1/tracks'
 
+TRACK_STATS_URL = 'https://api.spotify.com/v1/audio-features/'
+
 TRACKNUMBER = 'tracknumber'
 
 DISCNUMBER = 'discnumber'

--- a/zspotify/track.py
+++ b/zspotify/track.py
@@ -63,8 +63,8 @@ def get_song_duration(song_id: str) -> float:
     duration = float(ms_duration)/1000
 
     # debug
-    print(duration)
-    print(type(duration))
+    # print(duration)
+    # print(type(duration))
 
     return duration
 

--- a/zspotify/track.py
+++ b/zspotify/track.py
@@ -10,8 +10,8 @@ from pydub import AudioSegment
 from tqdm import tqdm
 
 from const import TRACKS, ALBUM, NAME, ITEMS, DISC_NUMBER, TRACK_NUMBER, IS_PLAYABLE, ARTISTS, IMAGES, URL, \
-    RELEASE_DATE, ID, TRACKS_URL, SAVED_TRACKS_URL, SPLIT_ALBUM_DISCS, ROOT_PATH, DOWNLOAD_FORMAT, CHUNK_SIZE, \
-    SKIP_EXISTING_FILES, ANTI_BAN_WAIT_TIME, OVERRIDE_AUTO_WAIT, BITRATE, CODEC_MAP, EXT_MAP, DOWNLOAD_REAL_TIME
+    RELEASE_DATE, ID, TRACKS_URL, SAVED_TRACKS_URL, TRACK_STATS_URL, SPLIT_ALBUM_DISCS, ROOT_PATH, DOWNLOAD_FORMAT, \
+    CHUNK_SIZE, SKIP_EXISTING_FILES, ANTI_BAN_WAIT_TIME, OVERRIDE_AUTO_WAIT, BITRATE, CODEC_MAP, EXT_MAP, DOWNLOAD_REAL_TIME
 from utils import fix_filename, set_audio_tags, set_music_thumbnail, create_download_directory, \
     get_directory_song_ids, add_to_directory_song_ids
 from zspotify import ZSpotify
@@ -52,6 +52,21 @@ def get_song_info(song_id) -> Tuple[List[str], str, str, Any, Any, Any, Any, Any
 
     return artists, album_name, name, image_url, release_year, disc_number, track_number, scraped_song_id, is_playable
 
+def get_song_duration(song_id: str) -> float:
+    """ Retrieves duration of song in second as is on spotify """
+
+    resp = ZSpotify.invoke_url(f'{TRACK_STATS_URL}{song_id}')
+
+    # get duration in miliseconds
+    ms_duration = resp['duration_ms']
+    # convert to seconds
+    duration = float(ms_duration)/1000
+
+    # debug
+    print(duration)
+    print(type(duration))
+
+    return duration
 
 # noinspection PyBroadException
 def download_track(track_id: str, extra_paths='', prefix=False, prefix_value='', disable_progressbar=False) -> None:

--- a/zspotify/utils.py
+++ b/zspotify/utils.py
@@ -55,12 +55,9 @@ def get_downloaded_song_duration(filename: str) -> float:
     command = ['ffprobe', '-show_entries', 'format=duration', '-i', f'{filename}']
     output = subprocess.run(command, capture_output=True)
 
-    print(output.stdout)
-
     duration = re.search(r'[\D]=([\d\.]*)', str(output.stdout)).groups()[0]
     duration = float(duration)
 
-    print(duration)
     return duration
 
 def wait(seconds: int = 3) -> None:

--- a/zspotify/utils.py
+++ b/zspotify/utils.py
@@ -1,6 +1,7 @@
 import os
 import platform
 import re
+import subprocess
 import time
 from enum import Enum
 from typing import List, Tuple
@@ -47,6 +48,20 @@ def add_to_directory_song_ids(download_path: str, song_id: str) -> None:
     # to be raised if something is wrong
     with open(hidden_file_path, 'a', encoding='utf-8') as file:
         file.write(f'{song_id}\n')
+
+def get_downloaded_song_duration(filename: str) -> float:
+    """ Returns the downloaded file's duration in seconds """
+
+    command = ['ffprobe', '-show_entries', 'format=duration', '-i', f'{filename}']
+    output = subprocess.run(command, capture_output=True)
+
+    print(output.stdout)
+
+    duration = re.search(r'[\D]=([\d\.]*)', str(output.stdout)).groups()[0]
+    duration = float(duration)
+
+    print(duration)
+    return duration
 
 def wait(seconds: int = 3) -> None:
     """ Pause for a set number of seconds """


### PR DESCRIPTION
 - New constant in const.py:
TRACK_STATS_URL = 'https://api.spotify.com/v1/audio-features/'

 - New function in track.py:
get_song_duration(): makes a request to the API for audio features
which contain the song's duration in milliseconds. Converts milliseconds
to seconds.

 - New function in utils.py:
get_downloaded_song_duration(): uses the subprocess module to run
an ffmpeg command that outputs the duration of the song file in seconds.
Output is captured and returned as float.

Once we decide what we'll do for incomplete tracks I can implement these functions into the program's logic.