### PR TITLE
feat: Improve Docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,5 @@ FROM base
 
 COPY --from=builder /install /usr/local
 COPY zspotify /app
-COPY *zs_config.json /
 WORKDIR /app
 ENTRYPOINT ["/usr/local/bin/python", "__main__.py"]

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Pull the official docker image (automatically updates):
 Or build the docker image yourself from the Dockerfile:
   docker build -t zspotify .
 Create and run a container from the image:
-  docker run --rm -v "$PWD/ZSpotify Music:/ZSpotify Music" -v "$PWD/ZSpotify Podcasts:/ZSpotify Podcasts" -it zspotify
+  docker run --rm -u $(id -u):$(id -g) -v "$PWD/zspotify:/app" -v "$PWD/zs_config.json:/zs_config.json" -v "$PWD/ZSpotify Music:/ZSpotify Music" -v "$PWD/ZSpotify Podcasts:/ZSpotify Podcasts" -it zspotify
 ```
 
 ### Google Colab


### PR DESCRIPTION
- Remember credentials between container starts
- Use same uid/gid in container as on host

The credentials saving is kind of a hack to preserve backwards compatibility. It would be far cleaner to instead put all persistent config files in a directory and mount that, but I'm not sure if you'd like to break everyone's setup doing so...