### PR TITLE
Better error output if get_song_info fails

### DIFF
--- a/zspotify/album.py
+++ b/zspotify/album.py
@@ -26,18 +26,18 @@ def get_album_tracks(album_id):
 
 def get_album_name(album_id):
     """ Returns album name """
-    resp = ZSpotify.invoke_url(f'{ALBUM_URL}/{album_id}')
+    (raw, resp) = ZSpotify.invoke_url(f'{ALBUM_URL}/{album_id}')
     return resp[ARTISTS][0][NAME], fix_filename(resp[NAME])
 
 
 def get_artist_albums(artist_id):
     """ Returns artist's albums """
-    resp = ZSpotify.invoke_url(f'{ARTIST_URL}/{artist_id}/albums?include_groups=album%2Csingle')
+    (raw, resp) = ZSpotify.invoke_url(f'{ARTIST_URL}/{artist_id}/albums?include_groups=album%2Csingle')
     # Return a list each album's id
     album_ids = [resp[ITEMS][i][ID] for i in range(len(resp[ITEMS]))]
     # Recursive requests to get all albums including singles an EPs
     while resp['next'] is not None:
-        resp = ZSpotify.invoke_url(resp['next'])
+        (raw, resp) = ZSpotify.invoke_url(resp['next'])
         album_ids.extend([resp[ITEMS][i][ID] for i in range(len(resp[ITEMS]))])
 
     return album_ids

--- a/zspotify/playlist.py
+++ b/zspotify/playlist.py
@@ -42,7 +42,7 @@ def get_playlist_songs(playlist_id):
 
 def get_playlist_info(playlist_id):
     """ Returns information scraped from playlist """
-    resp = ZSpotify.invoke_url(f'{PLAYLISTS_URL}/{playlist_id}?fields=name,owner(display_name)&market=from_token')
+    (raw, resp) = ZSpotify.invoke_url(f'{PLAYLISTS_URL}/{playlist_id}?fields=name,owner(display_name)&market=from_token')
     return resp['name'].strip(), resp['owner']['display_name'].strip()
 
 

--- a/zspotify/podcast.py
+++ b/zspotify/podcast.py
@@ -14,7 +14,7 @@ SHOWS_URL = 'https://api.spotify.com/v1/shows'
 
 
 def get_episode_info(episode_id_str) -> Tuple[Optional[str], Optional[str]]:
-    info = ZSpotify.invoke_url(f'{EPISODE_INFO_URL}/{episode_id_str}')
+    (raw, info) = ZSpotify.invoke_url(f'{EPISODE_INFO_URL}/{episode_id_str}')
     if ERROR in info:
         return None, None
     return fix_filename(info[SHOW][NAME]), fix_filename(info[NAME])

--- a/zspotify/zspotify.py
+++ b/zspotify/zspotify.py
@@ -86,7 +86,8 @@ class ZSpotify:
     @classmethod
     def invoke_url(cls, url):
         headers = cls.get_auth_header()
-        return requests.get(url, headers=headers).json()
+        response = requests.get(url, headers=headers)
+        return response.text, response.json()
 
     @classmethod
     def check_premium(cls) -> bool:


### PR DESCRIPTION
Prints the stacktrace and (if possible) the raw api output, in case of an `FAILED TO QUERY METADATA` 