### PR TITLE
return resolved paths from config.py

### DIFF
--- a/zspotify/config.py
+++ b/zspotify/config.py
@@ -129,11 +129,11 @@ class Config:
 
     @classmethod
     def get_root_path(cls) -> str:
-        return cls.get(ROOT_PATH)
+        return os.path.join(os.path.dirname(__file__), cls.get(ROOT_PATH))
 
     @classmethod
     def get_root_podcast_path(cls) -> str:
-        return cls.get(ROOT_PODCAST_PATH)
+        return os.path.join(os.path.dirname(__file__), cls.get(ROOT_PODCAST_PATH))
 
     @classmethod
     def get_skip_existing_files(cls) -> bool:
@@ -181,11 +181,11 @@ class Config:
 
     @classmethod
     def get_song_archive(cls) -> str:
-        return cls.get(SONG_ARCHIVE)
+        return os.path.join(ZSpotify.CONFIG.get_root_path(), cls.get(SONG_ARCHIVE))
 
     @classmethod
     def get_credentials_location(cls) -> str:
-        return cls.get(CREDENTIALS_LOCATION)
+        return os.path.join(os.getcwd(), cls.get(CREDENTIALS_LOCATION))
 
     @classmethod
     def get_output(cls, mode: str) -> str:

--- a/zspotify/podcast.py
+++ b/zspotify/podcast.py
@@ -77,11 +77,7 @@ def download_episode(episode_id) -> None:
         direct_download_url = ZSpotify.invoke_url(
             'https://api-partner.spotify.com/pathfinder/v1/query?operationName=getEpisode&variables={"uri":"spotify:episode:' + episode_id + '"}&extensions={"persistedQuery":{"version":1,"sha256Hash":"224ba0fd89fcfdfb3a15fa2d82a6112d3f4e2ac88fba5c6713de04d1b72cf482"}}')["data"]["episode"]["audio"]["items"][-1]["url"]
 
-        download_directory = os.path.join(
-            os.path.dirname(__file__),
-            ZSpotify.CONFIG.get_root_podcast_path(),
-            extra_paths,
-        )
+        download_directory = os.path.join(ZSpotify.CONFIG.get_root_podcast_path(), extra_paths)
         download_directory = os.path.realpath(download_directory)
         create_download_directory(download_directory)
 

--- a/zspotify/track.py
+++ b/zspotify/track.py
@@ -93,7 +93,7 @@ def download_track(mode: str, track_id: str, extra_keys={}, disable_progressbar=
         output_template = output_template.replace("{track_id}", fix_filename(track_id))
         output_template = output_template.replace("{ext}", EXT_MAP.get(ZSpotify.CONFIG.get_download_format().lower()))
 
-        filename = os.path.join(os.path.dirname(__file__), ZSpotify.CONFIG.get_root_path(), output_template)
+        filename = os.path.join(ZSpotify.CONFIG.get_root_path(), output_template)
         filedir = os.path.dirname(filename)
 
         check_name = os.path.isfile(filename) and os.path.getsize(filename)
@@ -161,7 +161,7 @@ def download_track(mode: str, track_id: str, extra_keys={}, disable_progressbar=
 
                     time_finished = time.time()
 
-                    Printer.print(PrintChannel.DOWNLOADS, f'###   Downloaded "{song_name}" to "{os.path.relpath(filename, os.path.dirname(__file__))}" in {fmt_seconds(time_downloaded - time_start)} (plus {fmt_seconds(time_finished - time_downloaded)} converting)   ###' + "\n")
+                    Printer.print(PrintChannel.DOWNLOADS, f'###   Downloaded "{song_name}" to "{os.path.relpath(filename, ZSpotify.CONFIG.get_root_path())}" in {fmt_seconds(time_downloaded - time_start)} (plus {fmt_seconds(time_finished - time_downloaded)} converting)   ###' + "\n")
 
                     # add song id to archive file
                     if ZSpotify.CONFIG.get_skip_previously_downloaded():

--- a/zspotify/utils.py
+++ b/zspotify/utils.py
@@ -36,7 +36,7 @@ def get_previously_downloaded() -> List[str]:
     """ Returns list of all time downloaded songs """
 
     ids = []
-    archive_path = os.path.join(os.path.dirname(__file__), ZSpotify.CONFIG.get_root_path(), ZSpotify.CONFIG.get_song_archive())
+    archive_path = ZSpotify.CONFIG.get_song_archive()
 
     if os.path.exists(archive_path):
         with open(archive_path, 'r', encoding='utf-8') as f:
@@ -48,7 +48,7 @@ def get_previously_downloaded() -> List[str]:
 def add_to_archive(song_id: str, filename: str, author_name: str, song_name: str) -> None:
     """ Adds song id to all time installed songs archive """
 
-    archive_path = os.path.join(os.path.dirname(__file__), ZSpotify.CONFIG.get_root_path(), ZSpotify.CONFIG.get_song_archive())
+    archive_path = ZSpotify.CONFIG.get_song_archive()
 
     if os.path.exists(archive_path):
         with open(archive_path, 'a', encoding='utf-8') as file:

--- a/zspotify/zspotify.py
+++ b/zspotify/zspotify.py
@@ -35,7 +35,7 @@ class ZSpotify:
     def login(cls):
         """ Authenticates with Spotify and saves credentials to a file """
 
-        cred_location = os.path.join(os.getcwd(), Config.get_credentials_location())
+        cred_location = Config.get_credentials_location()
 
         if os.path.isfile(cred_location):
             try:


### PR DESCRIPTION
A small-ish refactoring, to return the resolved paths from the config class (this way we don't have to os.path.join everywhere)