### PR TITLE
Skip songs with id==None

### DIFF
--- a/zspotify/app.py
+++ b/zspotify/app.py
@@ -49,7 +49,7 @@ def client(args) -> None:
     if args.liked_songs:
         for song in get_saved_tracks():
             if not song[TRACK][NAME]:
-                Printer.print(PrintChannel.ERRORS, '###   SKIPPING:  SONG DOES NOT EXIST ON SPOTIFY ANYMORE   ###' + "\n")
+                Printer.print(PrintChannel.SKIPS, '###   SKIPPING:  SONG DOES NOT EXIST ON SPOTIFY ANYMORE   ###' + "\n")
             else:
                 download_track('liked', song[TRACK][ID])
 
@@ -83,7 +83,10 @@ def download_from_urls(urls: list[str]) -> bool:
             playlist_songs = get_playlist_songs(playlist_id)
             name, _ = get_playlist_info(playlist_id)
             for song in playlist_songs:
-                download_track('playlist', song[TRACK][ID], extra_keys={'playlist': name})
+                if not song[TRACK][NAME]:
+                    Printer.print(PrintChannel.SKIPS, '###   SKIPPING:  SONG DOES NOT EXIST ON SPOTIFY ANYMORE   ###' + "\n")
+                else:
+                    download_track('playlist', song[TRACK][ID], extra_keys={'playlist': name})
         elif episode_id is not None:
             download = True
             download_episode(episode_id)

--- a/zspotify/podcast.py
+++ b/zspotify/podcast.py
@@ -70,7 +70,7 @@ def download_episode(episode_id) -> None:
     extra_paths = podcast_name + '/'
 
     if podcast_name is None:
-        Printer.print(PrintChannel.ERRORS, '###   SKIPPING: (EPISODE NOT FOUND)   ###')
+        Printer.print(PrintChannel.SKIPS, '###   SKIPPING: (EPISODE NOT FOUND)   ###')
     else:
         filename = podcast_name + ' - ' + episode_name
 

--- a/zspotify/track.py
+++ b/zspotify/track.py
@@ -126,6 +126,7 @@ def download_track(mode: str, track_id: str, extra_keys={}, disable_progressbar=
 
     except Exception as e:
         Printer.print(PrintChannel.ERRORS, '###   SKIPPING SONG - FAILED TO QUERY METADATA   ###')
+        Printer.print(PrintChannel.ERRORS, 'Track_ID: ' + str(track_id) + "\n")
         Printer.print(PrintChannel.ERRORS, str(e) + "\n")
         Printer.print(PrintChannel.ERRORS, "".join(traceback.TracebackException.from_exception(e).format()) + "\n")
     else:
@@ -191,6 +192,7 @@ def download_track(mode: str, track_id: str, extra_keys={}, disable_progressbar=
                         time.sleep(ZSpotify.CONFIG.get_anti_ban_wait_time())
         except Exception as e:
             Printer.print(PrintChannel.ERRORS, '###   SKIPPING: ' + song_name + ' (GENERAL DOWNLOAD ERROR)   ###')
+            Printer.print(PrintChannel.ERRORS, 'Track_ID: ' + str(track_id) + "\n")
             Printer.print(PrintChannel.ERRORS, str(e) + "\n")
             Printer.print(PrintChannel.ERRORS, "".join(traceback.TracebackException.from_exception(e).format()) + "\n")
             if os.path.exists(filename_temp):


### PR DESCRIPTION
If you have locally added songs in your playlist they have id = None and we get a Metadata-query-error.

This PR skips them early (same logic as in liked_songs)