### PR TITLE
removed Git Dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ffmpy
-git+https://github.com/kokarare1212/librespot-python
+https://github.com/kokarare1212/librespot-python/archive/refs/heads/rewrite.zip
 music_tag
 Pillow
 protobuf

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,6 @@ setup(
     ],
     packages=['zspotify'],
     install_requires=['ffmpy', 'music_tag', 'Pillow', 'protobuf', 'tabulate', 'tqdm',
-                      'librespot @ git+https://github.com/kokarare1212/librespot-python'],
+                      'librespot @ https://github.com/kokarare1212/librespot-python/archive/refs/heads/rewrite.zip'],
     include_package_data=True,
 )


### PR DESCRIPTION
since pip can install from zip archives, git is not needed to install the librespot python repo if pulling the zip file.