### PR TITLE
Only query genres if track does not get skipped

### DIFF
--- a/zspotify/app.py
+++ b/zspotify/app.py
@@ -19,8 +19,7 @@ def client(args) -> None:
     """ Connects to spotify to perform query's and get songs to download """
     ZSpotify(args)
 
-    if ZSpotify.CONFIG.get_print_splash():
-        Printer.print(PrintChannel.SPLASH, splash())
+    Printer.print(PrintChannel.SPLASH, splash())
 
     if ZSpotify.check_premium():
         Printer.print(PrintChannel.SPLASH, '[ DETECTED PREMIUM ACCOUNT - USING VERY_HIGH QUALITY ]\n\n')

--- a/zspotify/config.py
+++ b/zspotify/config.py
@@ -70,6 +70,7 @@ OUTPUT_DEFAULT_LIKED_SONGS = 'Liked Songs/{artist} - {song_name}.{ext}'
 OUTPUT_DEFAULT_SINGLE = '{artist} - {song_name}.{ext}'
 OUTPUT_DEFAULT_ALBUM = '{artist}/{album}/{album_num} - {artist} - {song_name}.{ext}'
 
+
 class Config:
     Values = {}
 
@@ -206,15 +207,11 @@ class Config:
         return os.path.join(cls.get_root_path(), cls.get(TEMP_DOWNLOAD_DIR))
     
     @classmethod
-    def get_allGenres(cls) -> bool:
+    def get_all_genres(cls) -> bool:
         return cls.get(MD_ALLGENRES)
 
     @classmethod
-    def get_print_splash(cls) -> bool:
-        return cls.get(PRINT_SPLASH)
-
-    @classmethod
-    def get_allGenresDelimiter(cls) -> bool:
+    def get_all_genres_delimiter(cls) -> bool:
         return cls.get(MD_GENREDELIMITER)
     
     @classmethod
@@ -248,3 +245,7 @@ class Config:
                 return os.path.join(split[0], 'Disc {disc_number}', split[0])
             return OUTPUT_DEFAULT_ALBUM
         raise ValueError()
+
+    @classmethod
+    def get_retry_attempts(cls) -> int:
+        return cls.get(RETRY_ATTEMPTS)

--- a/zspotify/const.py
+++ b/zspotify/const.py
@@ -34,6 +34,8 @@ ITEMS = 'items'
 
 NAME = 'name'
 
+HREF = 'href'
+
 ID = 'id'
 
 URL = 'url'

--- a/zspotify/utils.py
+++ b/zspotify/utils.py
@@ -129,7 +129,7 @@ def set_audio_tags(filename, artists, genres, name, album_name, release_year, di
     tags = music_tag.load_file(filename)
     tags[ALBUMARTIST] = artists[0]
     tags[ARTIST] = conv_artist_format(artists)
-    tags[GENRE] = genres[0] if not ZSpotify.CONFIG.get_allGenres() else ZSpotify.CONFIG.get_allGenresDelimiter().join(genres)
+    tags[GENRE] = genres[0] if not ZSpotify.CONFIG.get_all_genres() else ZSpotify.CONFIG.get_all_genres_delimiter().join(genres)
     tags[TRACKTITLE] = name
     tags[ALBUM] = album_name
     tags[YEAR] = release_year
@@ -273,9 +273,9 @@ def fmt_seconds(secs: float) -> str:
     h = math.floor(val)
 
     if h == 0 and m == 0 and s == 0:
-        return "0"
+        return "0s"
     elif h == 0 and m == 0:
-        return f'{s}'.zfill(2)
+        return f'{s}s'.zfill(2)
     elif h == 0:
         return f'{m}'.zfill(2) + ':' + f'{s}'.zfill(2)
     else:

--- a/zspotify/zspotify.py
+++ b/zspotify/zspotify.py
@@ -82,7 +82,7 @@ class ZSpotify:
         responsejson = response.json()
 
         if 'error' in responsejson:
-            if tryCount < (cls.CONFIG.retry_attemps - 1):
+            if tryCount < (cls.CONFIG.get_retry_attempts() - 1):
                 Printer.print(PrintChannel.WARNINGS, f"Spotify API Error (try {tryCount + 1}) ({responsejson['error']['status']}): {responsejson['error']['message']}")
                 time.sleep(5)
                 return cls.invoke_url(url, tryCount + 1)


### PR DESCRIPTION
Currently we query the genres for every track from the API, even if the song gets skipped in the next step because he's already downloaded.  
This slows everything down quite a lot and results in API rate limit errors.

This PR moves get_song_genres in its own method and only calls it after the song is already downloaded.

&nbsp;

Also `cls.CONFIG.retry_attemps` wouldn't compile and I changed it to `cls.CONFIG.get_retry_attempts()`

&nbsp;

Also removed the `if ZSpotify.CONFIG.get_print_splash():` guard, because the splash gets printed on the SPLASH channel we don't need it 